### PR TITLE
feat(Header.js):プラスアイコンを変更 #1

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -5,6 +5,7 @@ import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import AddIcon from '@material-ui/icons/Add';
+import Fab from '@material-ui/core/Fab';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -28,7 +29,13 @@ export default function Header() {
           <Typography variant="h6" className={classes.title}>
             WantToBuyList
           </Typography>
-          <AddIcon />
+          <Fab
+            size="small"
+            aria-label="add"
+            style={{ color: '#f57c00', backgroundColor: '#fff' }}
+          >
+            <AddIcon />
+          </Fab>
           <Button color="inherit">Login</Button>
         </Toolbar>
       </AppBar>


### PR DESCRIPTION
スクリーンショットの上から下に＋ボタンのアイコンを変更しました。
ご確認お願いします。

![スクリーンショット 2020-05-01 15 37 40](https://user-images.githubusercontent.com/61912316/80799943-24d50a00-8be3-11ea-885d-2c369a27ac47.png)
![スクリーンショット 2020-05-01 19 37 38](https://user-images.githubusercontent.com/61912316/80799997-4b934080-8be3-11ea-9d20-e44c4935928e.png)
